### PR TITLE
Remove image references from docs

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -28,21 +28,12 @@ A user with **Team with read membership** access in Buildkite must perform this 
 <Steps>
     <Step>
     In Buildkite, select your **Account Name** and click **Personal Settings**.
-    <Frame>
-    ![](/images/product/assets/buildkite_settings.png)
-    </Frame>
     </Step>
     <Step>
     On the left sidebar, select **API Access Tokens**.
-    <Frame>
-    ![](/images/product/assets/buildkite_api_access_token_link.png)
-    </Frame>
     </Step>
     <Step>
     Click **New API Access Token**.
-    <Frame>
-    ![](/images/product/assets/buildkite_token_btn.png)
-    </Frame>
     </Step>
     <Step>
     Name your token **C1 Integration** and select the following permissions:
@@ -116,7 +107,7 @@ Next, move on to the instructions for your chosen setup method.
     </Step>
 </Steps>
 
-**That's it!** Your Buildkite connector is now pulling access data into C1.
+**Done.** Your Buildkite connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 Follow these instructions to use the [Buildkite](https://github.com/conductorone/baton-buildkite) connector, hosted and run in your own environment.
@@ -222,11 +213,11 @@ spec:
     Create a namespace in which to run C1 connectors (if desired), then apply the secret config and deployment config files.
     </Step>
     <Step>
-    Check that the connector data uploaded correctly. In C1, click **Applications**. On the **Managed apps** tab, locate and click the name of the application you added the Buildkite connector to. Buildkite data should be found on the **Entitlements** and **Accounts** tabs.
+    Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Buildkite connector to. Buildkite data should be found on the **Entitlements** and **Accounts** pages.
     </Step>
 </Steps>
 
-**That's it!** Your Buildkite connector is now pulling access data into C1.
+**Done.** Your Buildkite connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Docs-only change. Updated text for UI accuracy and style guide adherence, plus removed unnecessary image frames from the instructions.
